### PR TITLE
Updating carbon 0.9.9 rpm to support relay and aggregator. Adding 0.9.10

### DIFF
--- a/carbon-0.9.10/carbon-aggregator.init
+++ b/carbon-0.9.10/carbon-aggregator.init
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# carbon-aggregator  init file for starting up the carbon-aggregator daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the carbon-aggregator daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/bin/carbon-aggregator.py"
+pidfile="/var/run/carbon-aggregator.pid"
+
+CONFIG="/etc/carbon/carbon.conf"
+LOG_DIR="/var/log/carbon-aggregator"
+
+[ -e /etc/sysconfig/carbon-aggregator ] && . /etc/sysconfig/carbon-aggregator
+
+lockfile=/var/lock/subsys/carbon-aggregator
+
+start() {
+    [ -f $CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting `basename $exec`: "
+    daemon "$exec --config=$CONFIG --pidfile=$pidfile --logdir=$LOG_DIR start"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping `basename $exec`: "
+    killproc -p $pidfile `basename $exec`
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status -p $pidfile `basename $exec`
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?
+

--- a/carbon-0.9.10/carbon-aggregator.sysconfig
+++ b/carbon-0.9.10/carbon-aggregator.sysconfig
@@ -1,0 +1,4 @@
+# Configuration file for carbon-aggregator
+
+# CONFIG=/etc/carbon/carbon.conf
+# LOG_DIR=/var/log/carbon-aggregator

--- a/carbon-0.9.10/carbon-cache.init
+++ b/carbon-0.9.10/carbon-cache.init
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# carbon-cache  init file for starting up the carbon-cache daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the carbon-cache daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/bin/carbon-cache.py"
+pidfile="/var/run/carbon-cache.pid"
+
+CONFIG="/etc/carbon/carbon.conf"
+LOG_DIR="/var/log/carbon-cache"
+
+[ -e /etc/sysconfig/carbon-cache ] && . /etc/sysconfig/carbon-cache
+
+lockfile=/var/lock/subsys/carbon-cache
+
+start() {
+    [ -f $CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting `basename $exec`: "
+    daemon "$exec --config=$CONFIG --pidfile=$pidfile --logdir=$LOG_DIR start"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping `basename $exec`: "
+    killproc -p $pidfile `basename $exec`
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status -p $pidfile `basename $exec`
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?
+

--- a/carbon-0.9.10/carbon-cache.sysconfig
+++ b/carbon-0.9.10/carbon-cache.sysconfig
@@ -1,0 +1,4 @@
+# Configuration file for carbon-cache
+
+# CONFIG=/etc/carbon/carbon.conf
+# LOG_DIR=/var/log/carbon-cache

--- a/carbon-0.9.10/carbon-config.patch
+++ b/carbon-0.9.10/carbon-config.patch
@@ -1,0 +1,30 @@
+diff -ru a/conf/carbon.conf.example b/conf/carbon.conf.example
+--- a/conf/carbon.conf.example	2011-10-05 08:17:52.000000000 +0100
++++ b/conf/carbon.conf.example	2011-10-17 15:15:41.000000000 +0100
+@@ -22,18 +22,18 @@
+ #   PID_DIR        = STORAGE_DIR/
+ #
+ # For FHS style directory structures, use:
+-#
+-#   STORAGE_DIR    = /var/lib/carbon/
+-#   CONF_DIR       = /etc/carbon/
+-#   LOG_DIR        = /var/log/carbon/
+-#   PID_DIR        = /var/run/
+-#
+-#LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
++
++STORAGE_DIR    = /var/lib/carbon/
++LOCAL_DATA_DIR = /var/lib/carbon/whisper/
++WHITELISTS_DIR = /var/lib/carbon/lists/
++CONF_DIR       = /etc/carbon/
++LOG_DIR        = /var/log/carbon/
++PID_DIR        = /var/run/
+ 
+ # Specify the user to drop privileges to
+ # If this is blank carbon runs as the user that invokes it
+ # This user must have write access to the local data directory
+-USER =
++USER = carbon
+ 
+ # Limit the size of the cache to avoid swapping or becoming CPU bound.
+ # Sorts and serving cache queries gets more expensive as the cache grows.

--- a/carbon-0.9.10/carbon-relay.init
+++ b/carbon-0.9.10/carbon-relay.init
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# carbon-relay  init file for starting up the carbon-relay daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the carbon-relay daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/bin/carbon-relay.py"
+pidfile="/var/run/carbon-relay.pid"
+
+CONFIG="/etc/carbon/carbon.conf"
+LOG_DIR="/var/log/carbon-relay"
+
+[ -e /etc/sysconfig/carbon-relay ] && . /etc/sysconfig/carbon-relay
+
+lockfile=/var/lock/subsys/carbon-relay
+
+start() {
+    [ -f $CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting `basename $exec`: "
+    daemon "$exec --config=$CONFIG --pidfile=$pidfile --logdir=$LOG_DIR start"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping `basename $exec`: "
+    killproc -p $pidfile `basename $exec`
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status -p $pidfile `basename $exec`
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?
+

--- a/carbon-0.9.10/carbon-relay.sysconfig
+++ b/carbon-0.9.10/carbon-relay.sysconfig
@@ -1,0 +1,4 @@
+# Configuration file for carbon-relay
+
+# CONFIG=/etc/carbon/carbon.conf
+# LOG_DIR=/var/log/carbon-relay

--- a/carbon-0.9.10/carbon-setup.patch
+++ b/carbon-0.9.10/carbon-setup.patch
@@ -1,0 +1,38 @@
+diff -Nru a/setup.cfg b/setup.cfg
+--- a/setup.cfg	2012-05-29 02:37:53.000000000 -0400
++++ b/setup.cfg	2012-05-31 20:30:06.404466573 -0400
+@@ -1,6 +1,3 @@
+-[install]
+-prefix = /opt/graphite
+-install-lib = %(prefix)s/lib
+ 
+ [bdist_rpm]
+ requires = python-twisted
+diff -Nru a/setup.py b/setup.py
+--- a/setup.py	2012-05-31 16:32:28.000000000 -0400
++++ b/setup.py	2012-05-31 20:31:16.031243493 -0400
+@@ -11,10 +11,12 @@
+   from distutils.core import setup
+   setup_kwargs = dict()
+ 
++storage_dirs = [
++    ('/var/lib/carbon/whisper',[]),
++    ('/var/lib/carbon/lists',[]),
++    ('/var/lib/carbon/rrd',[])
++]
+ 
+-storage_dirs = [ ('storage/whisper',[]), ('storage/lists',[]),
+-                 ('storage/log',[]), ('storage/rrd',[]) ]
+-conf_files = [ ('conf', glob('conf/*.example')) ]
+ #XXX Need a way to have these work for bdist_rpm but be left alone for everything else
+ #init_scripts = [ ('/etc/init.d', ['distro/redhat/init.d/carbon-cache',
+ #                                  'distro/redhat/init.d/carbon-relay',
+@@ -32,7 +34,7 @@
+   package_dir={'' : 'lib'},
+   scripts=glob('bin/*'),
+   package_data={ 'carbon' : ['*.xml'] },
+-  data_files=storage_dirs + conf_files, # + init_scripts,
++  data_files=storage_dirs,
+   install_requires=['twisted', 'txamqp'],
+   **setup_kwargs
+ )

--- a/carbon-0.9.10/carbon.spec
+++ b/carbon-0.9.10/carbon.spec
@@ -1,0 +1,156 @@
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+%define __getent   /usr/bin/getent
+%define __useradd  /usr/sbin/useradd
+%define __userdel  /usr/sbin/userdel
+%define __groupadd /usr/sbin/groupadd
+%define __touch    /bin/touch
+%define __service  /sbin/service
+
+Name:           carbon
+Version:        0.9.10
+Release:        1
+Summary:        Backend data caching and persistence daemon for Graphite
+Group:          Applications/Internet
+License:        Apache Software License 2.0
+URL:            https://launchpad.net/graphite
+Vendor:         Chris Davis <chrismd@gmail.com>
+Packager:       Dan Carley <dan.carley@gmail.com>
+Source0:        http://launchpad.net/graphite/0.9/%{version}/+download/%{name}-%{version}.tar.gz
+Patch0:         %{name}-setup.patch
+Patch1:         %{name}-config.patch
+Source1:        %{name}-cache.init
+Source2:        %{name}-cache.sysconfig
+Source3:        %{name}-relay.init
+Source4:        %{name}-relay.sysconfig
+Source5:        %{name}-aggregator.init
+Source6:        %{name}-aggregator.sysconfig
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+
+BuildRequires:  python python-devel python-setuptools
+Requires:       python whisper
+Requires:       python-twisted-core >= 8.0
+
+%description
+The backend for Graphite. Carbon is a data collection and storage agent.  
+
+%prep
+%setup -q
+%patch0 -p1
+%patch1 -p1
+
+%build
+CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")' build
+
+%install
+[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
+%{__python} -c 'import setuptools; execfile("setup.py")' install --skip-build --root %{buildroot}
+
+# Create log and var directories
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}-cache
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}-relay
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}-aggregator
+%{__mkdir_p} %{buildroot}%{_localstatedir}/lib/%{name}
+
+# Install system configuration and init scripts
+%{__install} -Dp -m0755 %{SOURCE1} %{buildroot}%{_initrddir}/%{name}-cache
+%{__install} -Dp -m0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}-cache
+%{__install} -Dp -m0755 %{SOURCE3} %{buildroot}%{_initrddir}/%{name}-relay
+%{__install} -Dp -m0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/sysconfig/%{name}-relay
+%{__install} -Dp -m0755 %{SOURCE5} %{buildroot}%{_initrddir}/%{name}-aggregator
+%{__install} -Dp -m0644 %{SOURCE6} %{buildroot}%{_sysconfdir}/sysconfig/%{name}-aggregator
+
+# Install default configuration files
+%{__mkdir_p} %{buildroot}%{_sysconfdir}/%{name}
+%{__install} -Dp -m0644 conf/carbon.conf.example %{buildroot}%{_sysconfdir}/%{name}/carbon.conf
+%{__install} -Dp -m0644 conf/storage-schemas.conf.example %{buildroot}%{_sysconfdir}/%{name}/storage-schemas.conf
+
+# Create transient files in buildroot for ghosting
+%{__mkdir_p} %{buildroot}%{_localstatedir}/lock/subsys
+%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}-cache
+%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}-relay
+%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}-aggregator
+
+%{__mkdir_p} %{buildroot}%{_localstatedir}/run
+%{__touch} %{buildroot}%{_localstatedir}/run/%{name}-cache.pid
+%{__touch} %{buildroot}%{_localstatedir}/run/%{name}-relay.pid
+%{__touch} %{buildroot}%{_localstatedir}/run/%{name}-aggregator.pid
+
+%pre
+%{__getent} group %{name} >/dev/null || %{__groupadd} -r %{name}
+%{__getent} passwd %{name} >/dev/null || \
+    %{__useradd} -r -g %{name} -d %{_localstatedir}/lib/%{name} \
+    -s /sbin/nologin -c "Carbon cache daemon" %{name}
+exit 0
+
+%preun
+%{__service} %{name}-cache stop
+%{__service} %{name}-relay stop
+%{__service} %{name}-aggregator stop
+exit 0
+
+%postun
+if [ $1 = 0 ]; then
+  %{__getent} passwd %{name} >/dev/null && \
+      %{__userdel} -r %{name} 2>/dev/null
+fi
+exit 0
+
+%clean
+[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc LICENSE PKG-INFO conf/*
+
+%{python_sitelib}/*
+/usr/bin/*
+%{_initrddir}/%{name}-cache
+%{_initrddir}/%{name}-relay
+%{_initrddir}/%{name}-aggregator
+
+%config(noreplace) %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-cache
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-relay
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-aggregator
+
+%attr(-,%name,%name) %{_localstatedir}/lib/%{name}
+%attr(-,%name,%name) %{_localstatedir}/log/%{name}-cache
+%attr(-,%name,%name) %{_localstatedir}/log/%{name}-relay
+%attr(-,%name,%name) %{_localstatedir}/log/%{name}-aggregator
+
+%ghost %{_localstatedir}/lock/subsys/%{name}-cache
+%ghost %{_localstatedir}/run/%{name}-cache.pid
+%ghost %{_localstatedir}/lock/subsys/%{name}-relay
+%ghost %{_localstatedir}/run/%{name}-relay.pid
+%ghost %{_localstatedir}/lock/subsys/%{name}-aggregator
+%ghost %{_localstatedir}/run/%{name}-aggregator.pid
+
+%changelog
+* Thu May 21 2012 Justin Burnham <justin@jburnham.net> - 0.9.10-1
+- New upstream version.
+
+* Fri Feb 17 2012 Justin Burnham <justin@jburnham.net> - 0.9.9-4
+- Adding carbon-relay and carbon-aggregator support.
+- Standardized naming to make things more specific.
+
+* Wed Nov 2 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-3
+- Correct python-twisted-core dependency from 0.8 to 8.0
+
+* Mon Oct 17 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-2
+- Fix config for relocated data directories.
+
+* Sat Oct 8 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-1
+- New upstream version.
+
+* Mon May 23 2011 Dan Carley <dan.carley@gmail.com> - 0.9.8-2
+- Repackage with minor changes.
+- Require later version of python-twisted-core to fix textFromEventDict error.
+
+* Tue Apr 19 2011 Chris Abernethy <cabernet@chrisabernethy.com> - 0.9.8-1
+- Update source to upstream v0.9.8
+- Minor updates to spec file
+
+* Thu Mar 17 2011 Daniel Aharon <daharon@sazze.com> - 0.9.7-1
+- Add dependencies, description, init script and sysconfig file.

--- a/carbon-0.9.9/carbon-aggregator.init
+++ b/carbon-0.9.9/carbon-aggregator.init
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# carbon-aggregator  init file for starting up the carbon-aggregator daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the carbon-aggregator daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/bin/carbon-aggregator.py"
+pidfile="/var/run/carbon-aggregator.pid"
+
+CONFIG="/etc/carbon/carbon.conf"
+LOG_DIR="/var/log/carbon-aggregator"
+
+[ -e /etc/sysconfig/carbon-aggregator ] && . /etc/sysconfig/carbon-aggregator
+
+lockfile=/var/lock/subsys/carbon-aggregator
+
+start() {
+    [ -f $CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting `basename $exec`: "
+    daemon "$exec --config=$CONFIG --pidfile=$pidfile --logdir=$LOG_DIR start"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping `basename $exec`: "
+    killproc -p $pidfile `basename $exec`
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status -p $pidfile `basename $exec`
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?
+

--- a/carbon-0.9.9/carbon-aggregator.sysconfig
+++ b/carbon-0.9.9/carbon-aggregator.sysconfig
@@ -1,0 +1,4 @@
+# Configuration file for carbon-aggregator
+
+# CONFIG=/etc/carbon/carbon.conf
+# LOG_DIR=/var/log/carbon-aggregator

--- a/carbon-0.9.9/carbon-cache.init
+++ b/carbon-0.9.9/carbon-cache.init
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# carbon-cache  init file for starting up the carbon-cache daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the carbon-cache daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/bin/carbon-cache.py"
+pidfile="/var/run/carbon-cache.pid"
+
+CONFIG="/etc/carbon/carbon.conf"
+LOG_DIR="/var/log/carbon-cache"
+
+[ -e /etc/sysconfig/carbon-cache ] && . /etc/sysconfig/carbon-cache
+
+lockfile=/var/lock/subsys/carbon-cache
+
+start() {
+    [ -f $CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting `basename $exec`: "
+    daemon "$exec --config=$CONFIG --pidfile=$pidfile --logdir=$LOG_DIR start"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping `basename $exec`: "
+    killproc -p $pidfile `basename $exec`
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status -p $pidfile `basename $exec`
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?
+

--- a/carbon-0.9.9/carbon-cache.sysconfig
+++ b/carbon-0.9.9/carbon-cache.sysconfig
@@ -1,0 +1,4 @@
+# Configuration file for carbon-cache
+
+# CONFIG=/etc/carbon/carbon.conf
+# LOG_DIR=/var/log/carbon-cache

--- a/carbon-0.9.9/carbon-relay.init
+++ b/carbon-0.9.9/carbon-relay.init
@@ -1,22 +1,22 @@
 #!/bin/sh
 #
-# carbon-cache  init file for starting up the carbon-cache daemon
+# carbon-relay  init file for starting up the carbon-relay daemon
 #
 # chkconfig:   - 20 80
-# description: Starts and stops the carbon-cache daemon.
+# description: Starts and stops the carbon-relay daemon.
 
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-exec="/usr/bin/carbon-cache.py"
-pidfile="/var/run/carbon.pid"
+exec="/usr/bin/carbon-relay.py"
+pidfile="/var/run/carbon-relay.pid"
 
 CONFIG="/etc/carbon/carbon.conf"
-LOG_DIR="/var/log/carbon"
+LOG_DIR="/var/log/carbon-relay"
 
-[ -e /etc/sysconfig/carbon ] && . /etc/sysconfig/carbon
+[ -e /etc/sysconfig/carbon-relay ] && . /etc/sysconfig/carbon-relay
 
-lockfile=/var/lock/subsys/carbon
+lockfile=/var/lock/subsys/carbon-relay
 
 start() {
     [ -f $CONFIG ] || exit 6
@@ -30,7 +30,7 @@ start() {
 }
 
 stop() {
-    echo -n $"Stopping carbon: "
+    echo -n $"Stopping `basename $exec`: "
     killproc -p $pidfile `basename $exec`
     retval=$?
     echo

--- a/carbon-0.9.9/carbon-relay.sysconfig
+++ b/carbon-0.9.9/carbon-relay.sysconfig
@@ -1,0 +1,4 @@
+# Configuration file for carbon-relay
+
+# CONFIG=/etc/carbon/carbon.conf
+# LOG_DIR=/var/log/carbon-relay

--- a/carbon-0.9.9/carbon.spec
+++ b/carbon-0.9.9/carbon.spec
@@ -9,7 +9,7 @@
 
 Name:           carbon
 Version:        0.9.9
-Release:        3
+Release:        4
 Summary:        Backend data caching and persistence daemon for Graphite
 Group:          Applications/Internet
 License:        Apache Software License 2.0
@@ -19,8 +19,12 @@ Packager:       Dan Carley <dan.carley@gmail.com>
 Source0:        http://launchpad.net/graphite/0.9/%{version}/+download/%{name}-%{version}.tar.gz
 Patch0:         %{name}-setup.patch
 Patch1:         %{name}-config.patch
-Source1:        %{name}.init
-Source2:        %{name}.sysconfig
+Source1:        %{name}-cache.init
+Source2:        %{name}-cache.sysconfig
+Source3:        %{name}-relay.init
+Source4:        %{name}-relay.sysconfig
+Source5:        %{name}-aggregator.init
+Source6:        %{name}-aggregator.sysconfig
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
@@ -44,12 +48,18 @@ CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")'
 %{__python} -c 'import setuptools; execfile("setup.py")' install --skip-build --root %{buildroot}
 
 # Create log and var directories
-%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}-cache
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}-relay
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}-aggregator
 %{__mkdir_p} %{buildroot}%{_localstatedir}/lib/%{name}
 
 # Install system configuration and init scripts
-%{__install} -Dp -m0755 %{SOURCE1} %{buildroot}%{_initrddir}/%{name}
-%{__install} -Dp -m0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+%{__install} -Dp -m0755 %{SOURCE1} %{buildroot}%{_initrddir}/%{name}-cache
+%{__install} -Dp -m0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}-cache
+%{__install} -Dp -m0755 %{SOURCE3} %{buildroot}%{_initrddir}/%{name}-relay
+%{__install} -Dp -m0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/sysconfig/%{name}-relay
+%{__install} -Dp -m0755 %{SOURCE5} %{buildroot}%{_initrddir}/%{name}-aggregator
+%{__install} -Dp -m0644 %{SOURCE6} %{buildroot}%{_sysconfdir}/sysconfig/%{name}-aggregator
 
 # Install default configuration files
 %{__mkdir_p} %{buildroot}%{_sysconfdir}/%{name}
@@ -58,10 +68,14 @@ CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")'
 
 # Create transient files in buildroot for ghosting
 %{__mkdir_p} %{buildroot}%{_localstatedir}/lock/subsys
-%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}
+%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}-cache
+%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}-relay
+%{__touch} %{buildroot}%{_localstatedir}/lock/subsys/%{name}-aggregator
 
 %{__mkdir_p} %{buildroot}%{_localstatedir}/run
-%{__touch} %{buildroot}%{_localstatedir}/run/%{name}.pid
+%{__touch} %{buildroot}%{_localstatedir}/run/%{name}-cache.pid
+%{__touch} %{buildroot}%{_localstatedir}/run/%{name}-relay.pid
+%{__touch} %{buildroot}%{_localstatedir}/run/%{name}-aggregator.pid
 
 %pre
 %{__getent} group %{name} >/dev/null || %{__groupadd} -r %{name}
@@ -90,18 +104,32 @@ exit 0
 
 %{python_sitelib}/*
 /usr/bin/*
-%{_initrddir}/%{name}
+%{_initrddir}/%{name}-cache
+%{_initrddir}/%{name}-relay
+%{_initrddir}/%{name}-aggregator
 
 %config %{_sysconfdir}/%{name}
-%config %{_sysconfdir}/sysconfig/%{name}
+%config %{_sysconfdir}/sysconfig/%{name}-cache
+%config %{_sysconfdir}/sysconfig/%{name}-relay
+%config %{_sysconfdir}/sysconfig/%{name}-aggregator
 
-%attr(-,%name,%name) %{_localstatedir}/log/%{name}
 %attr(-,%name,%name) %{_localstatedir}/lib/%{name}
+%attr(-,%name,%name) %{_localstatedir}/log/%{name}-cache
+%attr(-,%name,%name) %{_localstatedir}/log/%{name}-relay
+%attr(-,%name,%name) %{_localstatedir}/log/%{name}-aggregator
 
-%ghost %{_localstatedir}/lock/subsys/%{name}
-%ghost %{_localstatedir}/run/%{name}.pid
+%ghost %{_localstatedir}/lock/subsys/%{name}-cache
+%ghost %{_localstatedir}/run/%{name}-cache.pid
+%ghost %{_localstatedir}/lock/subsys/%{name}-relay
+%ghost %{_localstatedir}/run/%{name}-relay.pid
+%ghost %{_localstatedir}/lock/subsys/%{name}-aggregator
+%ghost %{_localstatedir}/run/%{name}-aggregator.pid
 
 %changelog
+* Fri Feb 17 2012 Justin Burnham <justin@jburnham.net> - 0.9.9-4
+- Adding carbon-relay and carbon-aggregator support.
+- Standardized naming to make things more specific.
+
 * Wed Nov 2 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-3
 - Correct python-twisted-core dependency from 0.8 to 8.0
 

--- a/carbon-0.9.9/carbon.sysconfig
+++ b/carbon-0.9.9/carbon.sysconfig
@@ -1,4 +1,0 @@
-# Configuration file for carbon
-
-# CONFIG=/etc/carbon/carbon.conf
-# LOG_DIR=/var/log/carbon

--- a/graphite-web-0.9.10/graphite-web-settings.patch
+++ b/graphite-web-0.9.10/graphite-web-settings.patch
@@ -1,0 +1,47 @@
+diff -Nru a/webapp/graphite/settings.py b/webapp/graphite/settings.py
+--- a/webapp/graphite/settings.py	2012-05-31 16:30:23.000000000 -0400
++++ b/webapp/graphite/settings.py	2012-06-01 13:49:00.845300636 -0400
+@@ -43,6 +43,7 @@
+ WHITELIST_FILE = ''
+ INDEX_FILE = ''
+ LOG_DIR = ''
++CARBON_DIR = '/var/lib/carbon'
+ WHISPER_DIR = ''
+ RRD_DIR = ''
+ DATA_DIRS = []
+@@ -119,29 +120,29 @@
+ ## Set config dependent on flags set in local_settings
+ # Path configuration
+ if not CONTENT_DIR:
+-  CONTENT_DIR = join(WEBAPP_DIR, 'content')
++  CONTENT_DIR = '/usr/share/graphite/webapp/content'
+ if not CSS_DIR:
+   CSS_DIR = join(CONTENT_DIR, 'css')
+ 
+ if not CONF_DIR:
+-  CONF_DIR = os.environ.get('GRAPHITE_CONF_DIR', join(GRAPHITE_ROOT, 'conf'))
++  CONF_DIR = '/etc/graphite-web'
+ if not DASHBOARD_CONF:
+   DASHBOARD_CONF = join(CONF_DIR, 'dashboard.conf')
+ if not GRAPHTEMPLATES_CONF:
+   GRAPHTEMPLATES_CONF = join(CONF_DIR, 'graphTemplates.conf')
+ 
+ if not STORAGE_DIR:
+-  STORAGE_DIR = os.environ.get('GRAPHITE_STORAGE_DIR', join(GRAPHITE_ROOT, 'storage'))
++  STORAGE_DIR = '/var/lib/graphite-web'
+ if not WHITELIST_FILE:
+   WHITELIST_FILE = join(STORAGE_DIR, 'lists', 'whitelist')
+ if not INDEX_FILE:
+   INDEX_FILE = join(STORAGE_DIR, 'index')
+ if not LOG_DIR:
+-  LOG_DIR = join(STORAGE_DIR, 'log', 'webapp')
++  LOG_DIR = '/var/log/graphite-web'
+ if not WHISPER_DIR:
+-  WHISPER_DIR = join(STORAGE_DIR, 'whisper/')
++  WHISPER_DIR = join(CARBON_DIR, 'whisper/')
+ if not RRD_DIR:
+-  RRD_DIR = join(STORAGE_DIR, 'rrd/')
++  RRD_DIR = join(CARBON_DIR, 'rrd/')
+ if not DATA_DIRS:
+   if rrdtool and os.path.exists(RRD_DIR):
+     DATA_DIRS = [WHISPER_DIR, RRD_DIR]

--- a/graphite-web-0.9.10/graphite-web-setup.patch
+++ b/graphite-web-0.9.10/graphite-web-setup.patch
@@ -1,0 +1,22 @@
+diff -Nru a/setup.cfg b/setup.cfg
+--- a/setup.cfg	2012-05-31 02:28:54.000000000 -0400
++++ b/setup.cfg	2012-06-01 13:53:32.505843979 -0400
+@@ -1,6 +1,5 @@
+ [install]
+-prefix = /opt/graphite
+-install-lib = %(prefix)s/webapp
++install-data=/usr/share/graphite
+ 
+ [bdist_rpm]
+ requires = Django => 1.1.4
+diff -Nru a/setup.py b/setup.py
+--- a/setup.py	2012-05-31 16:30:12.000000000 -0400
++++ b/setup.py	2012-06-01 13:54:59.066275567 -0400
+@@ -60,6 +60,6 @@
+   package_data={'graphite' :
+     ['templates/*', 'local_settings.py.example']},
+   scripts=glob('bin/*'),
+-  data_files=webapp_content.items() + storage_dirs + conf_files + examples,
++  data_files=webapp_content.items(),
+   **setup_kwargs
+ )

--- a/graphite-web-0.9.10/graphite-web-vhost.patch
+++ b/graphite-web-0.9.10/graphite-web-vhost.patch
@@ -1,0 +1,99 @@
+diff -Nru a/examples/example-graphite-vhost.conf b/examples/example-graphite-vhost.conf
+--- a/examples/example-graphite-vhost.conf	2012-05-31 02:28:54.000000000 -0400
++++ b/examples/example-graphite-vhost.conf	2012-06-01 14:03:23.298594686 -0400
+@@ -1,14 +1,14 @@
+ # This needs to be in your server's config somewhere, probably
+ # the main httpd.conf
+-# NameVirtualHost *:80
++NameVirtualHost *:80
+ 
+ # This line also needs to be in your server's config.
+ # LoadModule wsgi_module modules/mod_wsgi.so
+ 
+ # You need to manually edit this file to fit your needs.
+ # This configuration assumes the default installation prefix
+-# of /opt/graphite/, if you installed graphite somewhere else
+-# you will need to change all the occurances of /opt/graphite/
++# of /usr/share/graphite/, if you installed graphite somewhere else
++# you will need to change all the occurances of /usr/share/graphite/
+ # in this file to your chosen install location.
+ 
+ <IfModule !wsgi_module.c>
+@@ -17,44 +17,40 @@
+ 
+ # XXX You need to set this up!
+ # Read http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGISocketPrefix
+-WSGISocketPrefix run/wsgi
++WSGISocketPrefix /var/run/wsgi
+ 
+ <VirtualHost *:80>
+-        ServerName graphite
+-        DocumentRoot "/opt/graphite/webapp"
+-        ErrorLog /opt/graphite/storage/log/webapp/error.log
+-        CustomLog /opt/graphite/storage/log/webapp/access.log common
+-
+-        # I've found that an equal number of processes & threads tends
+-        # to show the best performance for Graphite (ymmv).
+-        WSGIDaemonProcess graphite processes=5 threads=5 display-name='%{GROUP}' inactivity-timeout=120
+-        WSGIProcessGroup graphite
+-        WSGIApplicationGroup %{GLOBAL}
+-        WSGIImportScript /opt/graphite/conf/graphite.wsgi process-group=graphite application-group=%{GLOBAL}
+-
+-        # XXX You will need to create this file! There is a graphite.wsgi.example
+-        # file in this directory that you can safely use, just copy it to graphite.wgsi
+-        WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi 
+-
+-        Alias /content/ /opt/graphite/webapp/content/
+-        <Location "/content/">
+-                SetHandler None
+-        </Location>
+-
+-        # XXX In order for the django admin site media to work you
+-        # must change @DJANGO_ROOT@ to be the path to your django
+-        # installation, which is probably something like:
+-        # /usr/lib/python2.6/site-packages/django
+-        Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
+-        <Location "/media/">
+-                SetHandler None
+-        </Location>
+-
+-        # The graphite.wsgi file has to be accessible by apache. It won't
+-        # be visible to clients because of the DocumentRoot though.
+-        <Directory /opt/graphite/conf/>
+-                Order deny,allow
+-                Allow from all
+-        </Directory>
++    ServerName   graphite
++    DocumentRoot /usr/share/graphite/webapp
+ 
++    ErrorLog     /var/log/graphite-web/error.log
++    CustomLog    /var/log/graphite-web/access.log combined
++
++    # I've found that an equal number of processes & threads tends
++    # to show the best performance for Graphite (ymmv).
++    WSGIDaemonProcess       graphite processes=5 threads=5 display-name='%{GROUP}' inactivity-timeout=120
++    WSGIProcessGroup        graphite
++    WSGIApplicationGroup    %{GLOBAL}
++
++    WSGIImportScript        /usr/share/graphite/graphite-web.wsgi process-group=graphite application-group=%{GLOBAL}
++    WSGIScriptAlias         / /usr/share/graphite/graphite-web.wsgi
++
++    Alias /content/ /usr/share/graphite/webapp/content/
++    <Location "/content/">
++        SetHandler None
++    </Location>
++
++    # You may need to modify the path to your Django installation
++    # root, i.e., if you are using Python v2.6.
++    Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
++    <Location "/media/">
++        SetHandler None
++    </Location>
++
++    # The graphite.wsgi file has to be accessible by apache. It won't
++    # be visible to clients because of the DocumentRoot though.
++    <Directory /usr/share/graphite/>
++        Order deny,allow
++        Allow from all
++    </Directory>
+ </VirtualHost>

--- a/graphite-web-0.9.10/graphite-web-wsgi.patch
+++ b/graphite-web-0.9.10/graphite-web-wsgi.patch
@@ -1,0 +1,10 @@
+diff -ru a/conf/graphite.wsgi.example b/conf/graphite.wsgi.example
+--- a/conf/graphite.wsgi.example	2011-04-04 03:32:41.000000000 +0100
++++ b/conf/graphite.wsgi.example	2011-05-14 23:48:34.000000000 +0100
+@@ -1,5 +1,5 @@
+ import os, sys
+-sys.path.append('/opt/graphite/webapp')
++sys.path.append('/usr/share/graphite/webapp')
+ os.environ['DJANGO_SETTINGS_MODULE'] = 'graphite.settings'
+ 
+ import django.core.handlers.wsgi

--- a/graphite-web-0.9.10/graphite-web.spec
+++ b/graphite-web-0.9.10/graphite-web.spec
@@ -1,0 +1,135 @@
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+%define __touch    /bin/touch
+%define __service  /sbin/service
+
+Name:           graphite-web
+Version:        0.9.10
+Release:        1
+Summary:        Enterprise scalable realtime graphing
+Group:          Applications/Internet
+License:        Apache License
+URL:            https://launchpad.net/graphite
+Vendor:         Chris Davis <chrismd@gmail.com>
+Packager:       Dan Carley <dan.carley@gmail.com>
+Source0:        http://launchpad.net/graphite/0.9/%{version}/+download/%{name}-%{version}.tar.gz
+Patch0:         graphite-web-setup.patch
+Patch1:         graphite-web-settings.patch
+Patch2:         graphite-web-vhost.patch
+Patch3:         graphite-web-wsgi.patch
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+BuildRequires:  python python-devel python-setuptools
+Requires:       Django django-tagging httpd mod_wsgi pycairo python-sqlite2 python-simplejson
+
+%description
+Graphite consists of a storage backend and a web-based visualization frontend.
+Client applications send streams of numeric time-series data to the Graphite
+backend (called carbon), where it gets stored in fixed-size database files
+similar in design to RRD. The web frontend provides 2 distinct user interfaces
+for visualizing this data in graphs as well as a simple URL-based API for
+direct graph generation.
+
+Graphite's design is focused on providing simple interfaces (both to users and
+applications), real-time visualization, high-availability, and enterprise
+scalability.
+
+%prep
+%setup -q
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+
+%build
+CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")' build
+
+%install
+[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
+%{__python} -c 'import setuptools; execfile("setup.py")' install --skip-build --root %{buildroot}
+
+# Create var directory with ghost files
+%{__mkdir_p} %{buildroot}%{_localstatedir}/lib/%{name}
+%{__touch} %{buildroot}%{_localstatedir}/lib/%{name}/graphite.db
+
+# Create log directory with ghost files
+%{__mkdir_p} %{buildroot}%{_localstatedir}/log/%{name}
+%{__touch} %{buildroot}%{_localstatedir}/log/%{name}/access.log
+%{__touch} %{buildroot}%{_localstatedir}/log/%{name}/error.log
+%{__touch} %{buildroot}%{_localstatedir}/log/%{name}/exception.log
+%{__touch} %{buildroot}%{_localstatedir}/log/%{name}/info.log
+
+# Create config directory and install configuration files
+%{__mkdir_p} %{buildroot}%{_sysconfdir}/%{name}
+%{__install} -Dp -m0644 conf/dashboard.conf.example %{buildroot}%{_sysconfdir}/%{name}/dashboard.conf
+%{__install} -Dp -m0644 webapp/graphite/local_settings.py.example %{buildroot}%{_sysconfdir}/%{name}/local_settings.py
+
+# Install the example wsgi controller and vhost configuration
+%{__install} -Dp -m0755 conf/graphite.wsgi.example %{buildroot}/usr/share/graphite/%{name}.wsgi
+%{__install} -Dp -m0644 examples/example-graphite-vhost.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/%{name}.conf
+
+# Create local_settings symlink
+%{__ln_s} %{_sysconfdir}/%{name}/local_settings.py %{buildroot}%{python_sitelib}/graphite/local_settings.py
+
+%post
+# Initialize the database
+%{__python} %{python_sitelib}/graphite/manage.py syncdb --noinput >/dev/null
+%{__chown} apache:apache %{_localstatedir}/lib/%{name}/graphite.db
+
+%posttrans
+# TEMPORARY FIX
+#
+# The 0.9.8-x versions of this RPM symlinked local_settings.py in during %post
+# and removed it during %preun. This was replaced in 0.9.9-1 with a standard
+# %files entry.
+#
+# When upgrading from 0.9.8 to 0.9.9 the %preun action of the previous version
+# removes the %files entry of the new version. This check reinstates the
+# symlink. It does not affect fresh installs and can be removed in subsequent
+# releases.
+[ -e %{python_sitelib}/graphite/local_settings.py ] || \
+    %{__ln_s} %{_sysconfdir}/%{name}/local_settings.py %{python_sitelib}/graphite/local_settings.py
+
+%clean
+[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc INSTALL LICENSE PKG-INFO conf/* examples/*
+
+%{python_sitelib}/*
+/usr/bin/*
+/usr/share/graphite
+/etc/httpd/conf.d/%{name}.conf
+
+%config(noreplace) %{_sysconfdir}/%{name}
+%config(noreplace) /etc/httpd/conf.d/%{name}.conf
+
+%attr(775,root,apache) %dir %{_localstatedir}/log/%{name}
+%ghost %{_localstatedir}/log/%{name}/access.log
+%ghost %{_localstatedir}/log/%{name}/error.log
+%ghost %{_localstatedir}/log/%{name}/exception.log
+%ghost %{_localstatedir}/log/%{name}/info.log
+
+%attr(775,root,apache) %dir %{_localstatedir}/lib/%{name}
+%ghost %{_localstatedir}/lib/%{name}/graphite.db
+
+%changelog
+* Fri Jun 1 2012 Justin Burnham <justin@jburnham.net> - 0.9.10-1
+- New upstream version.
+
+* Sat Oct 8 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-1
+- New upstream version.
+
+* Mon May 23 2011 Dan Carley <dan.carley@gmail.com> - 0.9.8-2
+- Repackage with some tidying.
+- Move state directory to /var/lib
+- Remove debug print to stdout.
+- Don't restart Apache. Kind of obtrusive.
+
+* Tue Apr 19 2011 Chris Abernethy <cabernet@chrisabernethy.com> - 0.9.8-1
+- Update source to upstream v0.9.8
+- Minor updates to spec file
+
+* Tue Mar 23 2010 Ilya Zakreuski <izakreuski@gmail.com> 0.9.5-1
+- Initial release.

--- a/whisper-0.9.10/whisper.spec
+++ b/whisper-0.9.10/whisper.spec
@@ -1,0 +1,58 @@
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+Name:           whisper
+Version:        0.9.10
+Release:        1
+Summary:        Fixed size round-robin style database
+Group:          Applications/Databases
+License:        Apache Software License 2.0
+URL:            https://launchpad.net/graphite
+Vendor:         Chris Davis <chrismd@gmail.com>
+Packager:       Dan Carley <dan.carley@gmail.com>
+Source0:        http://launchpad.net/graphite/0.9/%{version}/+download/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+
+BuildRequires:  python python-devel python-setuptools
+Requires:       python
+
+%description
+Whisper is a fixed-size database, similar in design to RRD.  It provides fast,
+reliable storage of numeric data over time.
+
+%prep
+%setup -q
+
+%build
+CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")' build
+
+%install
+[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
+%{__python} -c 'import setuptools; execfile("setup.py")' install --skip-build --root %{buildroot}
+
+%clean
+[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc PKG-INFO
+
+%{python_sitelib}/*
+/usr/bin/*
+
+%changelog
+* Fri Jun 1 2012 Justin Burnham <justin@jburnham.net> - 0.9.10-1
+- New upstream version.
+
+* Sat Oct 8 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-1
+- New upstream version.
+
+* Mon May 23 2011 Dan Carley <dan.carley@gmail.com> - 0.9.8-2
+- Repackage with minor changes.
+
+* Tue Apr 20 2011 Chris Abernethy <cabernet@chrisabernethy.com> - 0.9.8-1
+- Update source to upstream v0.9.8
+- Minor updates to spec file
+
+* Thu Mar 17 2011 Daniel Aharon <daharon@sazze.com> - 0.9.7-1
+- Add dependencies and description.


### PR DESCRIPTION
- Adding carbon-relay and carbon-aggregator support.
- Standardized naming to make things more specific.

This changes the carbon init script to instead be carbon-cache, and then adds new init scripts for relay and aggregator.

Logs will now be split into separate /var/log/carbon-{cache,relay,aggregator} paths.
Each daemon on startup will read from the appropriate /etc/sysconfig file for additional configuration options.
