### PR TITLE
Do not require pysqlite2 on EL6 since it is already included as sqlite3

### DIFF
--- a/graphite-web-0.9.10/graphite-web.spec
+++ b/graphite-web-0.9.10/graphite-web.spec
@@ -5,7 +5,7 @@
 
 Name:           graphite-web
 Version:        0.9.10
-Release:        1
+Release:        2
 Summary:        Enterprise scalable realtime graphing
 Group:          Applications/Internet
 License:        Apache License
@@ -21,7 +21,8 @@ Patch4:         graphite-web-python24compat.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 BuildRequires:  python python-devel python-setuptools
-Requires:       Django django-tagging httpd mod_wsgi pycairo python-sqlite2 python-simplejson
+Requires:       Django django-tagging httpd mod_wsgi pycairo python-simplejson
+%{?el5:Requires: python-sqlite2}
 
 %description
 Graphite consists of a storage backend and a web-based visualization frontend.
@@ -116,6 +117,9 @@ CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")'
 %ghost %{_localstatedir}/lib/%{name}/graphite.db
 
 %changelog
+* Mon Jul 30 2012 Brian Pitts <brian@polibyte.com> - 0.9.10-2
+- Do not require pysqlite2 on EL6 since it is already included as sqlite3
+
 * Fri Jun 1 2012 Ben P <ben@g.megatron.org> - 0.9.10-1
 - New upstream version.
 

--- a/graphite-web-0.9.8/graphite-web.spec
+++ b/graphite-web-0.9.8/graphite-web.spec
@@ -5,7 +5,7 @@
 
 Name:           graphite-web
 Version:        0.9.8
-Release:        2
+Release:        3
 Summary:        Enterprise scalable realtime graphing
 Group:          Applications/Internet
 License:        Apache License
@@ -19,7 +19,8 @@ Patch1:         graphite-config.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 BuildRequires:  python python-devel python-setuptools
-Requires:       Django httpd mod_wsgi pycairo python-sqlite2
+Requires:       Django httpd mod_wsgi pycairo
+%{?el5:Requires: python-sqlite2}
 
 %description
 Graphite consists of a storage backend and a web-based visualization frontend.
@@ -103,6 +104,9 @@ CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")'
 %ghost %{_localstatedir}/lib/%{name}/graphite.db
 
 %changelog
+* Mon Jul 30 2012 Brian Pitts <brian@polibyte.com> - 0.9.10-2
+- Do not require pysqlite2 on EL6 since it is already included as sqlite3
+
 * Mon May 23 2011 Dan Carley <dan.carley@gmail.com> - 0.9.8-2
 - Repackage with some tidying.
 - Move state directory to /var/lib

--- a/graphite-web-0.9.9/graphite-web.spec
+++ b/graphite-web-0.9.9/graphite-web.spec
@@ -5,7 +5,7 @@
 
 Name:           graphite-web
 Version:        0.9.9
-Release:        1
+Release:        2
 Summary:        Enterprise scalable realtime graphing
 Group:          Applications/Internet
 License:        Apache License
@@ -20,7 +20,8 @@ Patch3:         graphite-web-wsgi.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 BuildRequires:  python python-devel python-setuptools
-Requires:       Django django-tagging httpd mod_wsgi pycairo python-sqlite2 python-simplejson
+Requires:       Django django-tagging httpd mod_wsgi pycairo python-simplejson
+%{?el5:Requires: python-sqlite2}
 
 %description
 Graphite consists of a storage backend and a web-based visualization frontend.
@@ -114,6 +115,9 @@ CFLAGS="$RPM_OPT_FLAGS" %{__python} -c 'import setuptools; execfile("setup.py")'
 %ghost %{_localstatedir}/lib/%{name}/graphite.db
 
 %changelog
+* Mon Jul 30 2012 Brian Pitts <brian@polibyte.com> - 0.9.10-2
+- Do not require pysqlite2 on EL6 since it is already included as sqlite3
+
 * Sat Oct 8 2011 Dan Carley <dan.carley@gmail.com> - 0.9.9-1
 - New upstream version.
 


### PR DESCRIPTION
The python-sqlite2 package is only needed with Python version 2.4 and earlier (like EL5 has). In Python 2.5 and newer (EL6 has Python 2.6), the pysqlite2 module is included in the standard library under the name sqlite3. I believe that Graphite tries to import sqlite3 first, and only if it fails does it import pysqlite2, so removing the dependency when it is not needed should not change any behavior.
