### PR TITLE
Fix GitHub download URLs

### DIFF
--- a/carbon-0.9.10/carbon.spec
+++ b/carbon-0.9.10/carbon.spec
@@ -16,7 +16,7 @@ License:        Apache Software License 2.0
 URL:            https://launchpad.net/graphite
 Vendor:         Chris Davis <chrismd@gmail.com>
 Packager:       Dan Carley <dan.carley@gmail.com>
-Source0:        https://github.com/downloads/graphite-project/%{name}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/graphite-project/%{name}/downloads/%{name}-%{version}.tar.gz
 Patch0:         %{name}-setup.patch
 Patch1:         %{name}-config.patch
 Source1:        %{name}-cache.init

--- a/graphite-web-0.9.10/graphite-web.spec
+++ b/graphite-web-0.9.10/graphite-web.spec
@@ -12,7 +12,7 @@ License:        Apache License
 URL:            https://launchpad.net/graphite
 Vendor:         Chris Davis <chrismd@gmail.com>
 Packager:       Dan Carley <dan.carley@gmail.com>
-Source0:        https://github.com/downloads/graphite-project/%{name}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/graphite-project/%{name}/downloads/%{name}-%{version}.tar.gz
 Patch0:         graphite-web-setup.patch
 Patch1:         graphite-web-settings.patch
 Patch2:         graphite-web-vhost.patch

--- a/whisper-0.9.10/whisper.spec
+++ b/whisper-0.9.10/whisper.spec
@@ -9,7 +9,7 @@ License:        Apache Software License 2.0
 URL:            https://launchpad.net/graphite
 Vendor:         Chris Davis <chrismd@gmail.com>
 Packager:       Dan Carley <dan.carley@gmail.com>
-Source0:        https://github.com/downloads/graphite-project/%{name}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/graphite-project/%{name}/downloads/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 


### PR DESCRIPTION
Source tags were pointing to incorrect download urls on github.com.
